### PR TITLE
[Task TG-259 for US TG-239] Burndown missing BV edge case issue fixed

### DIFF
--- a/burndown/taigaApi/getUserStory.py
+++ b/burndown/taigaApi/getUserStory.py
@@ -490,8 +490,11 @@ def userstory_custom_attribute_burndown_for_sprint_process(project_id, sprint_id
         custom_attribute_data = get_business_value(user_story_id, auth_token)
         custom_attribute_type_id = get_custom_attribute_type_id(project_id, auth_token, custom_attribute_name)
 
+        if not custom_attribute_type_id:
+            return {"bv_burndown": {"bv_burndown_data": []}}  
+
         if not custom_attribute_data:
-            custom_attribute_data = {'40203': '5'}  # Hardcoded value
+            custom_attribute_data[custom_attribute_type_id] = '0' 
 
         total_custom_attribute_value += int(custom_attribute_data[custom_attribute_type_id])
 


### PR DESCRIPTION
**Description**
If user stories were missing the BV tag for business value, an error was being thrown. It is being handled in this code change.

**Testing**
Tested through postman for failing condition and passing !! (localhost)
 
```
URL - http://127.0.0.1:5007/bv
Body - 
{
  "sprintId":"376610",
  "projectId":"1521714"
}
Response - 
{
    "data": {
        "bv_burndown": {
            "bv_burndown_data": [
                {
                    "completed": 0,
                    "date": "Mon, 29 Jan 2024 00:00:00 GMT",
                    "remaining": 58
                },
                {
                    "completed": 0,
                    "date": "Mon, 30 Jan 2024 00:00:00 GMT",
                    "remaining": 58
                },
                {
                    "completed": 0,
                    "date": "Mon, 31 Jan 2024 00:00:00 GMT",
                    "remaining": 58
                },
                {
                    "completed": 0,
                    "date": "Mon, 01 Feb 2024 00:00:00 GMT",
                    "remaining": 58
                },
                {
                    "completed": 0,
                    "date": "Mon, 02 Feb 2024 00:00:00 GMT",
                    "remaining": 58
                },
                {
                    "completed": 0,
                    "date": "Mon, 03 Feb 2024 00:00:00 GMT",
                    "remaining": 58
                },
                {
                    "completed": 0,
                    "date": "Mon, 04 Feb 2024 00:00:00 GMT",
                    "remaining": 58
                },
                {
                    "completed": 0,
                    "date": "Mon, 05 Feb 2024 00:00:00 GMT",
                    "remaining": 58
                },
                {
                    "completed": 0,
                    "date": "Mon, 06 Feb 2024 00:00:00 GMT",
                    "remaining": 58
                },
                {
                    "completed": 0,
                    "date": "Mon, 07 Feb 2024 00:00:00 GMT",
                    "remaining": 58
                },
                {
                    "completed": 0,
                    "date": "Mon, 08 Feb 2024 00:00:00 GMT",
                    "remaining": 58
                },
                {
                    "completed": 0,
                    "date": "Mon, 09 Feb 2024 00:00:00 GMT",
                    "remaining": 58
                },
                {
                    "completed": 0,
                    "date": "Mon, 10 Feb 2024 00:00:00 GMT",
                    "remaining": 58
                },
                {
                    "completed": 0,
                    "date": "Mon, 11 Feb 2024 00:00:00 GMT",
                    "remaining": 58
                },
                {
                    "completed": 5,
                    "date": "Mon, 12 Feb 2024 00:00:00 GMT",
                    "remaining": 53
                },
                {
                    "completed": 5,
                    "date": "Mon, 13 Feb 2024 00:00:00 GMT",
                    "remaining": 48
                },
                {
                    "completed": 0,
                    "date": "Mon, 14 Feb 2024 00:00:00 GMT",
                    "remaining": 48
                },
                {
                    "completed": 0,
                    "date": "Mon, 15 Feb 2024 00:00:00 GMT",
                    "remaining": 48
                },
                {
                    "completed": 0,
                    "date": "Mon, 16 Feb 2024 00:00:00 GMT",
                    "remaining": 48
                },
                {
                    "completed": 0,
                    "date": "Mon, 17 Feb 2024 00:00:00 GMT",
                    "remaining": 48
                },
                {
                    "completed": 0,
                    "date": "Mon, 18 Feb 2024 00:00:00 GMT",
                    "remaining": 48
                },
                {
                    "completed": 38,
                    "date": "Mon, 19 Feb 2024 00:00:00 GMT",
                    "remaining": 10
                },
                {
                    "completed": 5,
                    "date": "Mon, 20 Feb 2024 00:00:00 GMT",
                    "remaining": 5
                },
                {
                    "completed": 5,
                    "date": "Mon, 13 Mar 2024 00:00:00 GMT",
                    "remaining": 0
                }
            ]
        }
    },
    "status": "success"
}
